### PR TITLE
fix: logo container style

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,8 @@ Other than the environment variables listed above, it is also possible to custom
        },
        # Update footer container styling via bootstrap classes
        "FOOTER_CUSTOM_CLASSNAMES": "py-5 px-4 text-center flex-column justify-content-center flex-wrap text-dark",
+       # Update footer logo container styling via bootstrap classes
+       "FOOTER_LOGO_CONTAINER_CLASSNAMES": "",
        # Update footer logo styling
        "FOOTER_LOGO_STYLE": {
            "marginBottom": "2rem",

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -48,17 +48,19 @@ class SiteFooter extends React.Component {
         className={`footer d-flex border-top py-3 px-4 ${config.FOOTER_CUSTOM_CLASSNAMES || ''}`}
         style={config.FOOTER_CUSTOM_STYLE}
       >
-        <a
-          className="d-block"
-          href={config.LMS_BASE_URL}
-          aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
-        >
-          <img
-            style={{ maxHeight: 45, ...config.FOOTER_LOGO_STYLE }}
-            src={logo || config.LOGO_TRADEMARK_URL}
-            alt={intl.formatMessage(messages['footer.logo.altText'])}
-          />
-        </a>
+        <div className={`d-flex justify-content-center ${config.FOOTER_LOGO_CONTAINER_CLASSNAMES || ''}`}>
+          <a
+            className="d-block"
+            href={config.LMS_BASE_URL}
+            aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
+          >
+            <img
+              style={{ maxHeight: 45, ...config.FOOTER_LOGO_STYLE }}
+              src={logo || config.LOGO_TRADEMARK_URL}
+              alt={intl.formatMessage(messages['footer.logo.altText'])}
+            />
+          </a>
+        </div>
         <div className="flex-grow-1" />
         {Array.isArray(config.FOOTER_LINKS) && (
           <div className={`d-flex align-items-center justify-content-center ${config.FOOTER_LINKS_CONTAINER_CLASSNAMES || ''}`}>

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -5,21 +5,25 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
   className="footer d-flex border-top py-3 px-4 "
   role="contentinfo"
 >
-  <a
-    aria-label="edX Home"
-    className="d-block"
-    href="http://localhost:18000"
+  <div
+    className="d-flex justify-content-center "
   >
-    <img
-      alt="Powered by Open edX"
-      src="https://edx-cdn.org/v3/default/logo-trademark.svg"
-      style={
-        Object {
-          "maxHeight": 45,
+    <a
+      aria-label="edX Home"
+      className="d-block"
+      href="http://localhost:18000"
+    >
+      <img
+        alt="Powered by Open edX"
+        src="https://edx-cdn.org/v3/default/logo-trademark.svg"
+        style={
+          Object {
+            "maxHeight": 45,
+          }
         }
-      }
-    />
-  </a>
+      />
+    </a>
+  </div>
   <div
     className="flex-grow-1"
   />
@@ -74,22 +78,26 @@ exports[`<Footer /> renders correctly renders without a language selector 1`] = 
     }
   }
 >
-  <a
-    aria-label="edX Home"
-    className="d-block"
-    href="http://localhost:18000"
+  <div
+    className="d-flex justify-content-center "
   >
-    <img
-      alt="Powered by Open edX"
-      src="https://edx-cdn.org/v3/default/logo-trademark.svg"
-      style={
-        Object {
-          "color": "white",
-          "maxHeight": 45,
+    <a
+      aria-label="edX Home"
+      className="d-block"
+      href="http://localhost:18000"
+    >
+      <img
+        alt="Powered by Open edX"
+        src="https://edx-cdn.org/v3/default/logo-trademark.svg"
+        style={
+          Object {
+            "color": "white",
+            "maxHeight": 45,
+          }
         }
-      }
-    />
-  </a>
+      />
+    </a>
+  </div>
   <div
     className="flex-grow-1"
   />
@@ -133,22 +141,26 @@ exports[`<Footer /> renders correctly renders without a language selector in es 
     }
   }
 >
-  <a
-    aria-label="edX Home"
-    className="d-block"
-    href="http://localhost:18000"
+  <div
+    className="d-flex justify-content-center "
   >
-    <img
-      alt="Powered by Open edX"
-      src="https://edx-cdn.org/v3/default/logo-trademark.svg"
-      style={
-        Object {
-          "color": "white",
-          "maxHeight": 45,
+    <a
+      aria-label="edX Home"
+      className="d-block"
+      href="http://localhost:18000"
+    >
+      <img
+        alt="Powered by Open edX"
+        src="https://edx-cdn.org/v3/default/logo-trademark.svg"
+        style={
+          Object {
+            "color": "white",
+            "maxHeight": 45,
+          }
         }
-      }
-    />
-  </a>
+      />
+    </a>
+  </div>
   <div
     className="flex-grow-1"
   />


### PR DESCRIPTION
The logo/link was taking up full width of footer making almost whole of footer clickable.

**Before:**

![image](https://github.com/open-craft/frontend-component-footer/assets/10894099/60949b91-bf85-416e-8502-b7d10de7c3c7)


**After:**
![2023-11-09T16:20:05,423837222+05:30](https://github.com/open-craft/frontend-component-footer/assets/10894099/a5c1da02-d9f9-4d1c-a7d7-13b672bea441)
