### PR TITLE
feat: add inner container to limit width

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,8 @@ Other than the environment variables listed above, it is also possible to custom
        },
        # Update footer container styling via bootstrap classes
        "FOOTER_CUSTOM_CLASSNAMES": "py-5 px-4 text-center flex-column justify-content-center flex-wrap text-dark",
+       # Update footer inner conatiner styling via bootstray classes
+       "FOOTER_CONTAINER_CUSTOM_CLASSNAMES": "py-5 px-4 text-center flex-column justify-content-center flex-wrap text-dark"
        # Update footer logo styling
        "FOOTER_LOGO_STYLE": {
            "marginBottom": "2rem",

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -60,7 +60,7 @@ class SiteFooter extends React.Component {
                 >
                   {element.text}
                 </a>
-              )).reduce((prev, curr) => [prev, '|', curr])}
+              ))}
             </div>
           )}
           <div className="flex-grow-1" />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -49,18 +49,6 @@ class SiteFooter extends React.Component {
         style={config.FOOTER_CUSTOM_STYLE}
       >
         <div className={`container-xl py-2 d-flex align-items-center ${config.FOOTER_CONTAINER_CUSTOM_CLASSNAMES || ''}`}>
-          <a
-            className="d-block"
-            href={config.LMS_BASE_URL}
-            aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
-          >
-            <img
-              style={{ maxHeight: 45, ...config.FOOTER_LOGO_STYLE }}
-              src={logo || config.LOGO_TRADEMARK_URL}
-              alt={intl.formatMessage(messages['footer.logo.altText'])}
-            />
-          </a>
-          <div className="flex-grow-1" />
           {Array.isArray(config.FOOTER_LINKS) && (
             <div className={`d-flex align-items-center justify-content-center ${config.FOOTER_LINKS_CONTAINER_CLASSNAMES || ''}`}>
               {config.FOOTER_LINKS.map(element => (
@@ -75,6 +63,18 @@ class SiteFooter extends React.Component {
               )).reduce((prev, curr) => [prev, '|', curr])}
             </div>
           )}
+          <div className="flex-grow-1" />
+          <a
+            className="d-block"
+            href={config.LMS_BASE_URL}
+            aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
+          >
+            <img
+              style={{ maxHeight: 45, ...config.FOOTER_LOGO_STYLE }}
+              src={logo || config.LOGO_TRADEMARK_URL}
+              alt={intl.formatMessage(messages['footer.logo.altText'])}
+            />
+          </a>
           {showLanguageSelector && (
             <LanguageSelector
               options={supportedLanguages}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -54,7 +54,7 @@ class SiteFooter extends React.Component {
               {config.FOOTER_LINKS.map(element => (
                 <a
                   key={element.url}
-                  className={`px-3 ${config.FOOTER_LINKS_CLASSNAMES}`}
+                  className={`px-3 ${config.FOOTER_LINKS_CLASSNAMES || ''}`}
                   href={element.url}
                   target={element.target || 'blank'}
                 >

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -49,39 +49,39 @@ class SiteFooter extends React.Component {
         style={config.FOOTER_CUSTOM_STYLE}
       >
         <div className={`container-xl py-2 d-flex align-items-center ${config.FOOTER_CONTAINER_CUSTOM_CLASSNAMES || ''}`}>
-        <a
-          className="d-block"
-          href={config.LMS_BASE_URL}
-          aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
-        >
-          <img
-            style={{ maxHeight: 45, ...config.FOOTER_LOGO_STYLE }}
-            src={logo || config.LOGO_TRADEMARK_URL}
-            alt={intl.formatMessage(messages['footer.logo.altText'])}
-          />
-        </a>
-        <div className="flex-grow-1" />
-        {Array.isArray(config.FOOTER_LINKS) && (
-          <div className={`d-flex align-items-center justify-content-center ${config.FOOTER_LINKS_CONTAINER_CLASSNAMES || ''}`}>
-            {config.FOOTER_LINKS.map(element => (
-              <a
-                key={element.url}
-                className={`px-3 ${config.FOOTER_LINKS_CLASSNAMES}`}
-                href={element.url}
-                target={element.target || 'blank'}
-              >
-                {element.text}
-              </a>
-            )).reduce((prev, curr) => [prev, '|', curr])}
-          </div>
-        )}
-        {showLanguageSelector && (
-          <LanguageSelector
-            options={supportedLanguages}
-            onSubmit={onLanguageSelected}
-          />
-        )}
-      </div>
+          <a
+            className="d-block"
+            href={config.LMS_BASE_URL}
+            aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
+          >
+            <img
+              style={{ maxHeight: 45, ...config.FOOTER_LOGO_STYLE }}
+              src={logo || config.LOGO_TRADEMARK_URL}
+              alt={intl.formatMessage(messages['footer.logo.altText'])}
+            />
+          </a>
+          <div className="flex-grow-1" />
+          {Array.isArray(config.FOOTER_LINKS) && (
+            <div className={`d-flex align-items-center justify-content-center ${config.FOOTER_LINKS_CONTAINER_CLASSNAMES || ''}`}>
+              {config.FOOTER_LINKS.map(element => (
+                <a
+                  key={element.url}
+                  className={`px-3 ${config.FOOTER_LINKS_CLASSNAMES}`}
+                  href={element.url}
+                  target={element.target || 'blank'}
+                >
+                  {element.text}
+                </a>
+              )).reduce((prev, curr) => [prev, '|', curr])}
+            </div>
+          )}
+          {showLanguageSelector && (
+            <LanguageSelector
+              options={supportedLanguages}
+              onSubmit={onLanguageSelected}
+            />
+          )}
+        </div>
       </footer>
     );
   }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -48,6 +48,7 @@ class SiteFooter extends React.Component {
         className={`footer d-flex border-top py-3 px-4 ${config.FOOTER_CUSTOM_CLASSNAMES || ''}`}
         style={config.FOOTER_CUSTOM_STYLE}
       >
+        <div className={`container-xl py-2 d-flex align-items-center ${config.FOOTER_CONTAINER_CUSTOM_CLASSNAMES || ''}`}>
         <a
           className="d-block"
           href={config.LMS_BASE_URL}
@@ -80,7 +81,7 @@ class SiteFooter extends React.Component {
             onSubmit={onLanguageSelected}
           />
         )}
-
+      </div>
       </footer>
     );
   }

--- a/src/components/Footer.test.jsx
+++ b/src/components/Footer.test.jsx
@@ -15,6 +15,7 @@ const FooterWithContext = ({ locale = 'es' }) => {
       LMS_BASE_URL: process.env.LMS_BASE_URL,
       FOOTER_CUSTOM_STYLE: { color: 'black' },
       FOOTER_CUSTOM_CLASSNAMES: 'text-center',
+      FOOTER_CONTAINER_CUSTOM_CLASSNAMES: 'text-center',
       FOOTER_LOGO_STYLE: { color: 'white' },
       FOOTER_LINKS: [
         { url: 'https://openedx.org/terms-of-use/', text: 'Terms of service' },

--- a/src/components/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/__snapshots__/Footer.test.jsx.snap
@@ -5,62 +5,66 @@ exports[`<Footer /> renders correctly renders with a language selector 1`] = `
   className="footer d-flex border-top py-3 px-4 "
   role="contentinfo"
 >
-  <a
-    aria-label="edX Home"
-    className="d-block"
-    href="http://localhost:18000"
-  >
-    <img
-      alt="Powered by Open edX"
-      src="https://edx-cdn.org/v3/default/logo-trademark.svg"
-      style={
-        Object {
-          "maxHeight": 45,
-        }
-      }
-    />
-  </a>
   <div
-    className="flex-grow-1"
-  />
-  <form
-    className="form-inline justify-content-center"
-    onSubmit={[Function]}
+    className="container-xl py-2 d-flex align-items-center "
   >
     <div
-      className="form-group"
+      className="flex-grow-1"
+    />
+    <a
+      aria-label="edX Home"
+      className="d-block"
+      href="http://localhost:18000"
     >
-      <label
-        className="d-inline-block m-0"
-        htmlFor="site-footer-language-select"
+      <img
+        alt="Powered by Open edX"
+        src="https://edx-cdn.org/v3/default/logo-trademark.svg"
+        style={
+          Object {
+            "maxHeight": 45,
+          }
+        }
+      />
+    </a>
+    <form
+      className="form-inline justify-content-center"
+      onSubmit={[Function]}
+    >
+      <div
+        className="form-group"
       >
-        Choose Language
-      </label>
-      <select
-        className="form-control-sm mx-2"
-        defaultValue="en"
-        id="site-footer-language-select"
-        name="site-footer-language-select"
-      >
-        <option
-          value="en"
+        <label
+          className="d-inline-block m-0"
+          htmlFor="site-footer-language-select"
         >
-          English
-        </option>
-        <option
-          value="es"
+          Choose Language
+        </label>
+        <select
+          className="form-control-sm mx-2"
+          defaultValue="en"
+          id="site-footer-language-select"
+          name="site-footer-language-select"
         >
-          Español
-        </option>
-      </select>
-      <button
-        className="btn btn-outline-primary btn-sm"
-        type="submit"
-      >
-        Apply
-      </button>
-    </div>
-  </form>
+          <option
+            value="en"
+          >
+            English
+          </option>
+          <option
+            value="es"
+          >
+            Español
+          </option>
+        </select>
+        <button
+          className="btn btn-outline-primary btn-sm"
+          type="submit"
+        >
+          Apply
+        </button>
+      </div>
+    </form>
+  </div>
 </footer>
 `;
 
@@ -74,50 +78,52 @@ exports[`<Footer /> renders correctly renders without a language selector 1`] = 
     }
   }
 >
-  <a
-    aria-label="edX Home"
-    className="d-block"
-    href="http://localhost:18000"
+  <div
+    className="container-xl py-2 d-flex align-items-center text-center"
   >
-    <img
-      alt="Powered by Open edX"
-      src="https://edx-cdn.org/v3/default/logo-trademark.svg"
-      style={
-        Object {
-          "color": "white",
-          "maxHeight": 45,
-        }
-      }
+    <div
+      className="d-flex align-items-center justify-content-center flex-wrap"
+    >
+      <a
+        className="px-3 text-dark font-weight-bold"
+        href="https://openedx.org/terms-of-use/"
+        target="blank"
+      >
+        Terms of service
+      </a>
+      <a
+        className="px-3 text-dark font-weight-bold"
+        href="https://openedx.org/code-of-conduct/"
+        target="blank"
+      >
+        Code of conduct
+      </a>
+      <a
+        className="px-3 text-dark font-weight-bold"
+        href="https://openedx.org/privacy-policy/"
+        target="blank"
+      >
+        Privacy Policy
+      </a>
+    </div>
+    <div
+      className="flex-grow-1"
     />
-  </a>
-  <div
-    className="flex-grow-1"
-  />
-  <div
-    className="d-flex align-items-center justify-content-center flex-wrap"
-  >
     <a
-      className="px-3 text-dark font-weight-bold"
-      href="https://openedx.org/terms-of-use/"
-      target="blank"
+      aria-label="edX Home"
+      className="d-block"
+      href="http://localhost:18000"
     >
-      Terms of service
-    </a>
-    |
-    <a
-      className="px-3 text-dark font-weight-bold"
-      href="https://openedx.org/code-of-conduct/"
-      target="blank"
-    >
-      Code of conduct
-    </a>
-    |
-    <a
-      className="px-3 text-dark font-weight-bold"
-      href="https://openedx.org/privacy-policy/"
-      target="blank"
-    >
-      Privacy Policy
+      <img
+        alt="Powered by Open edX"
+        src="https://edx-cdn.org/v3/default/logo-trademark.svg"
+        style={
+          Object {
+            "color": "white",
+            "maxHeight": 45,
+          }
+        }
+      />
     </a>
   </div>
 </footer>
@@ -133,50 +139,52 @@ exports[`<Footer /> renders correctly renders without a language selector in es 
     }
   }
 >
-  <a
-    aria-label="edX Home"
-    className="d-block"
-    href="http://localhost:18000"
+  <div
+    className="container-xl py-2 d-flex align-items-center text-center"
   >
-    <img
-      alt="Powered by Open edX"
-      src="https://edx-cdn.org/v3/default/logo-trademark.svg"
-      style={
-        Object {
-          "color": "white",
-          "maxHeight": 45,
-        }
-      }
+    <div
+      className="d-flex align-items-center justify-content-center flex-wrap"
+    >
+      <a
+        className="px-3 text-dark font-weight-bold"
+        href="https://openedx.org/terms-of-use/"
+        target="blank"
+      >
+        Terms of service
+      </a>
+      <a
+        className="px-3 text-dark font-weight-bold"
+        href="https://openedx.org/code-of-conduct/"
+        target="blank"
+      >
+        Code of conduct
+      </a>
+      <a
+        className="px-3 text-dark font-weight-bold"
+        href="https://openedx.org/privacy-policy/"
+        target="blank"
+      >
+        Privacy Policy
+      </a>
+    </div>
+    <div
+      className="flex-grow-1"
     />
-  </a>
-  <div
-    className="flex-grow-1"
-  />
-  <div
-    className="d-flex align-items-center justify-content-center flex-wrap"
-  >
     <a
-      className="px-3 text-dark font-weight-bold"
-      href="https://openedx.org/terms-of-use/"
-      target="blank"
+      aria-label="edX Home"
+      className="d-block"
+      href="http://localhost:18000"
     >
-      Terms of service
-    </a>
-    |
-    <a
-      className="px-3 text-dark font-weight-bold"
-      href="https://openedx.org/code-of-conduct/"
-      target="blank"
-    >
-      Code of conduct
-    </a>
-    |
-    <a
-      className="px-3 text-dark font-weight-bold"
-      href="https://openedx.org/privacy-policy/"
-      target="blank"
-    >
-      Privacy Policy
+      <img
+        alt="Powered by Open edX"
+        src="https://edx-cdn.org/v3/default/logo-trademark.svg"
+        style={
+          Object {
+            "color": "white",
+            "maxHeight": 45,
+          }
+        }
+      />
     </a>
   </div>
 </footer>


### PR DESCRIPTION
## Description

This PR does the following changes :

1. Adds a container within the footer [similar to header](https://github.com/openedx/frontend-component-header/blob/3b2a2bfa9576926fcf6278b222835d68752bba0e/src/learning-header/LearningHeader.jsx#L45), which would limit the width of the footer and align it to the header and main contents.
2. Reorders link and logo in footer as required by eSHE
3. Remove seperator between links

## Testing instructions

Use steps [defined here](https://github.com/openedx/frontend-component-footer/pull/311) to test the changes here in local devstack

## Other information

[BB-8576](https://tasks.opencraft.com/browse/BB-8576)